### PR TITLE
Be sure to include the branch when requesting file contents.

### DIFF
--- a/repo.js
+++ b/repo.js
@@ -192,7 +192,7 @@
                             el.addClass('active');
                         } else {
                             $.ajax({
-                                url: 'https://api.github.com/repos/' + _this.settings.user + '/' + _this.settings.name + '/contents/' + link.data('path'),
+                                url: 'https://api.github.com/repos/' + _this.settings.user + '/' + _this.settings.name + '/contents/' + link.data('path') + '?ref=' + _this.settings.branch,
                                 type: 'GET',
                                 data: {},
                                 dataType: 'jsonp',


### PR DESCRIPTION
When using repo.js on a branch the 'ref' wasn't being passed causing Github to attempt to return files from the master branch.
