### PR TITLE
Escaping dots in data-id pattern

### DIFF
--- a/repo.js
+++ b/repo.js
@@ -97,7 +97,7 @@
         };
 
         // Namespace - strip out characters that would have to be escaped to be used in selectors
-        _this.namespace = _this.settings.name.toLowerCase().replace(/[^a-z0-9]-_/g, '');
+        _this.namespace = _this.settings.name.toLowerCase().replace(/[^a-z0-9]-_/g, '').replace(/\./g, '_');
 
         // Check if this namespace is already in use
         var usedNamespaces = $('[data-id^='+ _this.namespace +']');


### PR DESCRIPTION
If the repo has a name with dots, it causes a jQuery syntax error.

Having a dot in the repo name was causing me some trouble. 
First I had nothing loading. So I escaped the dots in the namespace with \.
It made the repo appear, however I couldn't load anything in a folder.
Finally I simply replaced every dot with an underscore and now it seems to be working as expected.

Tested with jQuery 2.0.2.
