### PR TITLE
Escaping dots in data-id pattern

### DIFF
--- a/repo.js
+++ b/repo.js
@@ -97,7 +97,7 @@
         };
 
         // Namespace - strip out characters that would have to be escaped to be used in selectors
-        _this.namespace = _this.settings.name.toLowerCase().replace(/[^a-z0-9]-_/g, '');
+        _this.namespace = _this.settings.name.toLowerCase().replace(/[^a-z0-9_-]/g, '');
 
         // Check if this namespace is already in use
         var usedNamespaces = $('[data-id^='+ _this.namespace +']');


### PR DESCRIPTION
If the repo has a name with dots, it causes a jQuery syntax error.
The RegEx pattern was a bit weird, deleting everything that is not alphanumeric if it is followed by a dash and an underscore.
That pretty much matches nothing.
I think the underscore and the dash were meant to be inside the RegEx class so that everything that isn't alphanumeric, a dash or an underscore has to be escaped to prevent problems in selectors using the namespace.
