### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Repo.js is a jQuery plugin that lets you easily embed a Github repo onto your si
 
 Repo.js uses [Markus Ekwall](https://twitter.com/#!/mekwall)'s [jQuery Vangogh](https://github.com/mekwall/jquery-vangogh) plugin for styling of file contents. Vangogh, subsequently, utilizes [highlight.js](https://github.com/isagalaev/highlight.js), written by [Ivan Sagalaev](https://github.com/isagalaev) for syntax highlighting.
 
-##Example Usage
+## Example Usage
 
 ```javascript
 $('body').repo({ user: 'darcyclarke', name: 'Repo.js' });
@@ -26,7 +26,7 @@ You can also reference a specific branch if you want:
 $('body').repo({ user: 'jquery', name: 'jquery', branch: 'strip_iife' });
 ````
 
-##License
+## License
 
 Copyright (c) 2016 Darcy Clarke <darcy@darcyclarke.me>
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
